### PR TITLE
installation process based on shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
 .idea
+shell/Jarvis-personal-assistant/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron ./app/main.js",
     "build": "electron-packager . Jarvis-Desktop",
-    "test": "tests/travis.sh"
+    "test": "shell/travis.sh"
   },
   "repository": {
     "type": "git",

--- a/shell/install-jarvis-desktop.sh
+++ b/shell/install-jarvis-desktop.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+which npm
+
+cd ..
+echo "install development dependencies"
+npm install --dev
+
+echo "test existing code"
+npm test

--- a/shell/install-service.sh
+++ b/shell/install-service.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+which git
+which go
+
+echo "fetching jarvis-service from https://github.com/Harkishen-Singh/Jarvis-personal-assistant"
+
+git clone https://github.com/Harkishen-Singh/Jarvis-personal-assistant
+echo "finished"
+
+cd Jarvis-personal-assistant/service/
+echo "installing go dependencies"
+go get -u -v -d ./...
+
+echo "preparing to execute service .."
+go run maintut.go &
+echo "successfully executed the service"
+

--- a/shell/start-service.sh
+++ b/shell/start-service.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [ -d "Jarvis-personal-assistant" ]; then
+    echo "folder exists! skipping service installation steps"
+else
+    echo "Jarvis-personal-assistant directory does not exists! Downloading ..."
+    ./install-service.sh
+    echo "installation of Jarvis-personal-assistant service successful"
+fi
+
+cd Jarvis-personal-assistant/service/
+echo "preparing to execute service .."
+go run maintut.go &
+echo "successfully executed the service"

--- a/shell/travis.sh
+++ b/shell/travis.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 which eslint
 eslint app/*.js app/scripts/*.js
 


### PR DESCRIPTION
Automates the tedious installation process of :

1. Jarvis-personal-assistant
2. Jarvis-desktop
by using the shell processes.

To begin the service, the user needs to simply run ```./start-service.sh``` in **shell** directory.
*This would handle other processes as well, which includes downloading the service from git repository, through a subshell, if the service does not exist locally.*

To install the **Jarvis-Desktop**, run, ```./install-jarvis-desktop.sh``` in the **shell directory**.

To test **Travis**, run ```./travis.sh``` in the **shell directory**.